### PR TITLE
ab#59483 restore dual builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Google Cloud Secret Manager PAM Provider is supported by Keyfactor for Keyfactor
 
 ---
 
-
+When using this PAM Provider, there are 2 versions available to install depending on the Dot Net version in use.
+If you are using Keyfactor Command __before version 11__, you should install the PAM Provider from the `net472` folder.
+___Otherwise, by default___ you should install from the `netcoreapp3.1` folder. This folder should also be used when installing on the Universal Orchestrator.
 ---
 
 
@@ -58,6 +60,17 @@ After the secret is created, you can add the Role or Principal directly to it in
 
 #### [Authentication](https://cloud.google.com/docs/authentication/production)
 As a special requirement for authenticating with Google Cloud, you will need to generate and download a Service Account Key for your service account. This `json` file should be saved in a secure location on your machine. After saving it, you will need to configure the `GOOGLE_APPLICATION_CREDENTIALS` environment variable with the full path to the `json` file with the key material.
+
+
+#### Usage with the Keyfactor Universal Orchestrator
+To use the PAM Provider to resolve a field, for example a Server Password, instead of entering in the actual value for the Server Password, enter a `json` object with the parameters specifying the field.
+The parameters needed are the "instance" parameters above:
+
+~~~ json
+{"secretId":"gcp-secret-id"}
+~~~
+
+If a field supports PAM but should not use PAM, simply enter in the actual value to be used instead of the `json` format object above.
 
 #### In Keyfactor - PAM Provider
 ##### Installation

--- a/gcp-secretmanager-pam.csproj
+++ b/gcp-secretmanager-pam.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>GCP</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
@@ -22,9 +23,5 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
-
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy $(TargetDir)google* $(TargetDir)export\  /i&#xD;&#xA;if $(TargetFramework) == net472 xcopy $(TargetDir)grpc* $(TargetDir)export\  /i&#xD;&#xA;if $(TargetFramework) == net472 xcopy $(TargetDir)libgrpc* $(TargetDir)export\  /i&#xD;&#xA;if $(TargetFramework) == net472 xcopy $(TargetDir)Keyfactor.Platform.IPAMProvider.dll $(TargetDir)export\  /i" />
-  </Target>
 
 </Project>

--- a/integration-manifest.json
+++ b/integration-manifest.json
@@ -6,7 +6,7 @@
   "support_level": "kf-supported",
   "update_catalog": true,
   "link_github": true,
-  "release_dir": "bin/Release/netcoreapp3.1",
+  "release_dir": "bin/Release",
   "description": "The Google Cloud Secret Manager PAM Provider allows for the use of a Secret Manager instance in Google Cloud to be used as a credential store for Keyfactor. Secret values can be retrieved and used in the Keyfactor Platform as passwords or other sensitive fields.",
   "about": {
     "pam": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+	"extensions": {
+		"Keyfactor.Platform.Extensions.IPAMProvider": {
+			"PAMProviders.GCP-SecretManager.PAMProvider": {
+				"assemblyPath": "gcp-secretmanager-pam.dll",
+				"TypeFullName": "Keyfactor.Extensions.Pam.GCP.SecretManagerPAM"
+			}
+		}
+	},
+	"Keyfactor:PAMProviders:GCP-SecretManager:InitializationInfo": {
+		"projectId": "gcp-project-id"
+	}
+}

--- a/readme-src/readme-config.md
+++ b/readme-src/readme-config.md
@@ -8,3 +8,14 @@ After the secret is created, you can add the Role or Principal directly to it in
 
 #### [Authentication](https://cloud.google.com/docs/authentication/production)
 As a special requirement for authenticating with Google Cloud, you will need to generate and download a Service Account Key for your service account. This `json` file should be saved in a secure location on your machine. After saving it, you will need to configure the `GOOGLE_APPLICATION_CREDENTIALS` environment variable with the full path to the `json` file with the key material.
+
+
+#### Usage with the Keyfactor Universal Orchestrator
+To use the PAM Provider to resolve a field, for example a Server Password, instead of entering in the actual value for the Server Password, enter a `json` object with the parameters specifying the field.
+The parameters needed are the "instance" parameters above:
+
+~~~ json
+{"secretId":"gcp-secret-id"}
+~~~
+
+If a field supports PAM but should not use PAM, simply enter in the actual value to be used instead of the `json` format object above.

--- a/readme-src/readme-pre.md
+++ b/readme-src/readme-pre.md
@@ -1,0 +1,3 @@
+When using this PAM Provider, there are 2 versions available to install depending on the Dot Net version in use.
+If you are using Keyfactor Command __before version 11__, you should install the PAM Provider from the `net472` folder.
+___Otherwise, by default___ you should install from the `netcoreapp3.1` folder. This folder should also be used when installing on the Universal Orchestrator.


### PR DESCRIPTION
the `manifest.json` is added to this project with the necessary info. additional documentation is added for entering in JSON when using the PAM Provider on UO, and for selecting which of the two build folders to use.

since the GCP library is has different dependencies based on which Dot Net version is in use, there are 2 builds created which include the correct dependencies, and are targeted for either .NET Framework 4.7.2 (Command pre-11) or .NET Core 3.1 (UO and should be compatible with Command 11+)

fixes #8 